### PR TITLE
close sockets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,12 +16,10 @@
 //! ## Examples
 //!
 //! ```
-//! extern crate libicmp;
-//!
 //! use libicmp::PingBuilder;
 //!
 //! let p = PingBuilder::new()
-//!     .host("8.8.8.8")
+//!     .host("127.0.0.1")
 //!     .num_pings(5)
 //!     .interval_secs(1)
 //!     .timeout_secs(5)


### PR DESCRIPTION
`RawSocket::new()` allocates a new file descriptor and nothing ever closes that file descriptor, eventually causing a program to exhaust its file descriptor quota and crash after sending many pings. This change implements `Drop` for `RawSocket` such that the file descriptor is automatically closed when the socket struct is destroyed.

I also had to change the example in `lib.rs` because `cargo test` was complaining that it couldn't resolve `extern crate libicmp`. I think it's because the repository is called just "icmp".